### PR TITLE
Fix unnecessary double cast in ContentProviderUtils.java

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report issues of OpenTracks features
 title: ''
-labels: potential bug
+labels: enhancement
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/data_not_recorded.md
+++ b/.github/ISSUE_TEMPLATE/data_not_recorded.md
@@ -1,8 +1,8 @@
 ---
-name: Data not recorded 
-about: Somehow OpenTracks did not record GPS data 
+name: Data not recorded
+about: Somehow OpenTracks did not record GPS data
 title: ''
-labels: potential bug 
+labels: ''
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/technical-debt-template.md
+++ b/.github/ISSUE_TEMPLATE/technical-debt-template.md
@@ -1,0 +1,47 @@
+---
+name: Technical Debt template
+about: Use this template to report a technical debt issue
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+---
+name: Technical Debt report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the technical debt**
+A clear and concise description of what the technical debt is.
+
+**To Reproduce // if applicable**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of the proposed solution. Best is to show original technical debt and the resolution.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information): // if needed**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="6341_project_branch_rafsan">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/src/main/java/de/dennisguse/opentracks/data/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/data/ContentProviderUtils.java
@@ -389,8 +389,8 @@ public class ContentProviderUtils {
         Marker marker = new Marker(trackId, Instant.ofEpochMilli(cursor.getLong(timeIndex)));
 
         if (!cursor.isNull(longitudeIndex) && !cursor.isNull(latitudeIndex)) {
-            marker.setLongitude(((double) cursor.getInt(longitudeIndex)) / 1E6);
-            marker.setLatitude(((double) cursor.getInt(latitudeIndex)) / 1E6);
+            marker.setLongitude( cursor.getInt(longitudeIndex) / 1E6);
+            marker.setLatitude( cursor.getInt(latitudeIndex) / 1E6);
         }
         if (!cursor.isNull(altitudeIndex)) {
             marker.setAltitude(Altitude.WGS84.of(cursor.getFloat(altitudeIndex)));


### PR DESCRIPTION
**Description**
This pull request resolves a technical debt issue by removing an unnecessary cast to `double` in the `ContentProviderUtils.java` file. Java automatically promotes the result of dividing an integer by `1E6` to `double`, making the explicit cast redundant.

**Changes**
- Removed redundant `(double)` casts in the following methods:
  - `setLongitude()`
  - `setLatitude()`

**Link to the issue**
This PR fixes issue [#4](https://github.com/Jinish-Vaidya/opentracksFall2024/issues/4).